### PR TITLE
Add simple map for user pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Carte des utilisateurs
+
+Ce petit projet propose une page web où chaque utilisateur peut placer un seul marqueur sur une carte Leaflet.
+
+## Fonctionnement
+
+- Cliquez sur la carte pour positionner votre marqueur.
+- À la première utilisation, votre âge et votre genre vous seront demandés.
+- Le marqueur affichera ces informations quand un autre utilisateur cliquera dessus.
+- Les données sont stockées localement dans le navigateur via `localStorage`. Il n'y a pas de stockage côté serveur.
+
+Ouvrez simplement `index.html` dans un navigateur connecté à Internet pour charger Leaflet et utiliser la carte.

--- a/index.html
+++ b/index.html
@@ -1,2 +1,47 @@
-index.html
-README.md
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Carte des utilisateurs</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha256-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC0=" crossorigin=""/>
+<style>
+  #map { height: 100vh; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" integrity="sha256-ds5oE2prSeZnLGUC+9CgwVUFp3kxcPkTt3FOpFk0E4Y=" crossorigin=""></script>
+<script>
+// Initialize map
+var map = L.map('map').setView([0, 0], 2);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap'
+}).addTo(map);
+
+var stored = JSON.parse(localStorage.getItem('userPin'));
+var marker;
+if (stored) {
+  marker = L.marker(stored.latlng).addTo(map);
+  marker.bindPopup('Age : ' + stored.age + '<br>Genre : ' + stored.gender);
+}
+
+function addMarker(e) {
+  if (marker) {
+    alert('Vous avez déjà placé votre marqueur.');
+    return;
+  }
+  var age = prompt('Quel est votre âge ?');
+  if (!age) return;
+  var gender = prompt("Votre genre (homme/femme) ?");
+  if (!gender) return;
+  marker = L.marker(e.latlng).addTo(map);
+  marker.bindPopup('Age : ' + age + '<br>Genre : ' + gender).openPopup();
+  localStorage.setItem('userPin', JSON.stringify({latlng: e.latlng, age: age, gender: gender}));
+}
+
+map.on('click', addMarker);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Leaflet map in `index.html` so each user can place one pin storing age & gender
- include a README explaining how the page works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740bd65b70832e9f802cd6c4a26f78