### PR TITLE
Add interactive map with profile editing

### DIFF
--- a/accueil.html
+++ b/accueil.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <title>Accueil</title>
+</head>
+<body>
+<nav>
+  <a href="accueil.html">Accueil</a>
+  <a href="map.html">Carte</a>
+  <a href="profil.html">Profil</a>
+</nav>
+<main>
+  <h1>Bienvenue</h1>
+  <p><a href="map.html"><button>Aller sur la map</button></a></p>
+</main>
+<script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,2 +1,10 @@
-index.html
-README.md
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta http-equiv="refresh" content="0; URL=accueil.html">
+  <title>Redirection</title>
+</head>
+<body>
+  <p>Redirection vers <a href="accueil.html">l'accueil</a>...</p>
+</body>
+</html>

--- a/map.html
+++ b/map.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">
+  <link rel="stylesheet" href="style.css">
+  <title>Carte</title>
+</head>
+<body>
+<nav>
+  <a href="accueil.html">Accueil</a>
+  <a href="map.html">Carte</a>
+  <a href="profil.html">Profil</a>
+</nav>
+<main>
+  <h1>Carte interactive</h1>
+  <div id="map"></div>
+</main>
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/profil.html
+++ b/profil.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <title>Profil</title>
+</head>
+<body>
+<nav>
+  <a href="accueil.html">Accueil</a>
+  <a href="map.html">Carte</a>
+  <a href="profil.html">Profil</a>
+</nav>
+<main>
+  <h1>Mon profil</h1>
+  <form id="profileForm">
+    <label for="age">Âge</label>
+    <input type="number" id="age" min="1" required>
+    <label for="gender">Genre</label>
+    <select id="gender" required>
+      <option value="homme">Homme</option>
+      <option value="femme">Femme</option>
+    </select>
+    <button type="submit">Enregistrer</button>
+  </form>
+</main>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,60 @@
+function getPins() {
+  return JSON.parse(localStorage.getItem('pins') || '[]');
+}
+function savePins(pins) {
+  localStorage.setItem('pins', JSON.stringify(pins));
+}
+function initProfileForm() {
+  const ageInput = document.getElementById('age');
+  const genderSelect = document.getElementById('gender');
+  if (ageInput) ageInput.value = localStorage.getItem('age') || '';
+  if (genderSelect) genderSelect.value = localStorage.getItem('gender') || '';
+  const form = document.getElementById('profileForm');
+  if (form) {
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      localStorage.setItem('age', ageInput.value);
+      localStorage.setItem('gender', genderSelect.value);
+      alert('Profil mis \u00e0 jour');
+    });
+  }
+}
+function loadPins(map) {
+  getPins().forEach(p => {
+    L.marker([p.lat, p.lng]).addTo(map)
+      .bindPopup(`${p.age} ans \u2013 ${p.gender}`);
+  });
+}
+function initMap() {
+  const mapElem = document.getElementById('map');
+  if (!mapElem) return;
+  const map = L.map('map').setView([48.8584, 2.2945], 4);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a>'
+  }).addTo(map);
+  loadPins(map);
+  map.on('click', e => {
+    if (localStorage.getItem('hasPin')) {
+      alert('Vous avez d\u00e9j\u00e0 ajout\u00e9 un pin');
+      return;
+    }
+    const age = localStorage.getItem('age');
+    const gender = localStorage.getItem('gender');
+    if (!age || !gender) {
+      alert('Renseignez votre \u00e2ge et votre genre dans le profil');
+      return;
+    }
+    const marker = L.marker(e.latlng).addTo(map)
+      .bindPopup(`${age} ans \u2013 ${gender}`);
+    const pins = getPins();
+    pins.push({ lat: e.latlng.lat, lng: e.latlng.lng, age, gender });
+    savePins(pins);
+    localStorage.setItem('hasPin', 'true');
+    marker.openPopup();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initProfileForm();
+  initMap();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,10 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header, nav { background: #333; color: #fff; padding: 10px; }
+nav a { color: #fff; margin-right: 10px; text-decoration: none; }
+main { padding: 20px; }
+button { padding: 10px 20px; font-size: 16px; cursor: pointer; }
+form { max-width: 300px; margin: 0 auto; }
+label { display: block; margin-bottom: 5px; }
+input, select { width: 100%; padding: 8px; margin-bottom: 10px; }
+@media (max-width: 600px) { body { font-size: 14px; } }
+#map { width: 100%; height: 400px; margin-top: 20px; }


### PR DESCRIPTION
## Summary
- create basic style for all pages
- implement shared JS handling profile, pins and Leaflet
- add main pages: `accueil.html`, `map.html`, `profil.html`
- update root `index.html` to redirect to accueil

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740cdea284832eb33e919798d83a3b