### PR TITLE
Add interactive map site

### DIFF
--- a/accueil.html
+++ b/accueil.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accueil</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Bienvenue</h1>
+    <a class="button" href="map.html">Aller sur la map</a>
+    <nav>
+        <a href="profil.html">Profil</a>
+    </nav>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/map.html
+++ b/map.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Carte Interactive</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-sA+4w5C5Tg9HOfFpM9QubZsH4wMB36n8CDddXqpPyMo=" crossorigin=""/>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav>
+        <a href="accueil.html">Accueil</a>
+        <a href="profil.html">Profil</a>
+    </nav>
+    <div id="map" style="height: 80vh;"></div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-o9N1j6Ps3kwKvfYI+1nv1Dj6ww2cJaIcJfLkA/SmrE4=" crossorigin=""></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/profil.html
+++ b/profil.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profil</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav>
+        <a href="accueil.html">Accueil</a>
+        <a href="map.html">Carte</a>
+    </nav>
+    <h1>Mon Profil</h1>
+    <form id="profile-form">
+        <label for="age">Âge :</label>
+        <input type="number" id="age" name="age" required>
+        <label for="gender">Genre :</label>
+        <select id="gender" name="gender">
+            <option value="homme">Homme</option>
+            <option value="femme">Femme</option>
+        </select>
+        <button type="submit" class="button">Sauvegarder</button>
+    </form>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,62 @@
+function loadUserInfo() {
+    return JSON.parse(localStorage.getItem('userInfo') || '{}');
+}
+
+function saveUserInfo(age, gender) {
+    localStorage.setItem('userInfo', JSON.stringify({ age: age, gender: gender }));
+    const index = localStorage.getItem('userPinIndex');
+    if (index !== null) {
+        const pins = JSON.parse(localStorage.getItem('pins') || '[]');
+        if (pins[index]) {
+            pins[index].age = age;
+            pins[index].gender = gender;
+            localStorage.setItem('pins', JSON.stringify(pins));
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('profile-form');
+    if (form) {
+        const info = loadUserInfo();
+        if (info.age) form.age.value = info.age;
+        if (info.gender) form.gender.value = info.gender;
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            saveUserInfo(form.age.value, form.gender.value);
+            alert('Profil sauvegardé');
+        });
+    }
+
+    const mapEl = document.getElementById('map');
+    if (mapEl) {
+        const map = L.map('map').setView([48.8584, 2.2945], 13);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; OpenStreetMap'
+        }).addTo(map);
+
+        let pins = JSON.parse(localStorage.getItem('pins') || '[]');
+        pins.forEach(p => {
+            L.marker([p.lat, p.lng]).addTo(map)
+                .bindPopup(p.age + ' ans – ' + p.gender);
+        });
+
+        map.on('click', function (e) {
+            if (localStorage.getItem('userPinIndex') !== null) {
+                alert('Vous avez déjà ajouté un pin.');
+                return;
+            }
+            const info = loadUserInfo();
+            if (!info.age || !info.gender) {
+                alert('Veuillez remplir votre âge et genre dans le profil.');
+                return;
+            }
+            L.marker(e.latlng).addTo(map)
+                .bindPopup(info.age + ' ans – ' + info.gender)
+                .openPopup();
+            pins.push({ lat: e.latlng.lat, lng: e.latlng.lng, age: info.age, gender: info.gender });
+            localStorage.setItem('pins', JSON.stringify(pins));
+            localStorage.setItem('userPinIndex', pins.length - 1);
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,40 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+nav {
+    margin: 1em;
+}
+nav a {
+    margin-right: 1em;
+    text-decoration: none;
+    color: #007bff;
+}
+.button {
+    display: inline-block;
+    padding: 0.5em 1em;
+    background: #007bff;
+    color: white;
+    border-radius: 4px;
+    text-decoration: none;
+}
+form {
+    display: flex;
+    flex-direction: column;
+    width: 300px;
+}
+label {
+    margin-top: 0.5em;
+}
+input, select {
+    padding: 0.5em;
+}
+@media (max-width: 600px) {
+    form {
+        width: 90%;
+    }
+}


### PR DESCRIPTION
## Summary
- build multi-page site with Leaflet map
- enable one pin per user stored in localStorage
- create profile form for age/gender editing
- add navigation and basic responsive style

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68740dee0d04832e9cf4532a40953367