### PR TITLE
Improve map page and styling

### DIFF
--- a/accueil.html
+++ b/accueil.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <nav>
+    <img src="logo.svg" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>
     <a href="map.html">Carte</a>
     <a href="profil.html">Profil</a>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40" viewBox="0 0 120 40">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4a90e2" />
+      <stop offset="100%" stop-color="#00bcd4" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="40" rx="6" fill="url(#grad)" />
+  <text x="60" y="28" font-size="22" font-family="Segoe UI, sans-serif" fill="white" text-anchor="middle">Zwizz</text>
+</svg>

--- a/map.html
+++ b/map.html
@@ -3,13 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Use the locally installed Leaflet files instead of the CDN -->
-    <link rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css" />
+    <!-- Leaflet CSS with CDN fallback -->
+    <link rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css" onerror="this.href='https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'" />
     <link rel="stylesheet" href="style.css">
     <title>Carte</title>
 </head>
 <body>
 <nav>
+    <img src="logo.svg" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>
     <a href="map.html">Carte</a>
     <a href="profil.html">Profil</a>
@@ -18,8 +19,8 @@
     <h1>Carte interactive</h1>
     <div id="map" style="height: 80vh;"></div>
 </main>
-<!-- Load Leaflet from local dependencies -->
-<script src="node_modules/leaflet/dist/leaflet.js"></script>
+<!-- Load Leaflet with CDN fallback -->
+<script src="node_modules/leaflet/dist/leaflet.js" onerror="this.onerror=null;this.src='https://unpkg.com/leaflet@1.9.4/dist/leaflet.js'"></script>
 <script src="script.js"></script>
 </body>
 </html>

--- a/profil.html
+++ b/profil.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <nav>
+    <img src="logo.svg" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>
     <a href="map.html">Carte</a>
     <a href="profil.html">Profil</a>

--- a/style.css
+++ b/style.css
@@ -1,47 +1,82 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
     padding: 0;
+    background: #f0f2f5;
+    color: #333;
 }
+
 nav {
-    background: #333;
-    color: #fff;
-    padding: 10px;
+    background: #fff;
+    padding: 0.5em 1em;
+    display: flex;
+    align-items: center;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+nav .logo {
+    height: 40px;
+    margin-right: 1em;
+}
+
 nav a {
-    color: #fff;
+    color: #333;
     margin-right: 1em;
     text-decoration: none;
+    font-weight: bold;
 }
+
+nav a:hover {
+    text-decoration: underline;
+}
+
 main {
-    padding: 20px;
+    max-width: 800px;
+    margin: 2em auto;
+    background: #fff;
+    padding: 2em;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
 .button {
     display: inline-block;
     padding: 10px 20px;
-    background: #007bff;
+    background: linear-gradient(45deg, #4a90e2, #00bcd4);
     color: #fff;
     text-decoration: none;
     border-radius: 4px;
+    transition: background 0.3s ease;
 }
+
+.button:hover {
+    background: linear-gradient(45deg, #00bcd4, #4a90e2);
+}
+
 form {
     max-width: 300px;
     margin: 0 auto;
     display: flex;
     flex-direction: column;
 }
+
 label {
     margin-top: 0.5em;
 }
-input, select {
+
+input,
+select {
     padding: 0.5em;
     margin-bottom: 10px;
 }
+
 #map {
     width: 100%;
-    height: 400px;
+    height: 80vh;
     margin-top: 20px;
+    border-radius: 8px;
 }
+
 @media (max-width: 600px) {
     body {
         font-size: 14px;


### PR DESCRIPTION
## Summary
- modernize site styles and buttons
- show Zwizz logo in navigation
- fallback to CDN for Leaflet assets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874398521ec832e90a937f5256560e0