### PR TITLE
Add pin removal and about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
-    <title>Profil</title>
+    <title>À propos</title>
 </head>
 <body>
 <nav>
@@ -15,17 +15,8 @@
     <a href="about.html">À propos</a>
 </nav>
 <main>
-    <h1>Mon Profil</h1>
-    <form id="profile-form">
-        <label for="age">Âge :</label>
-        <input type="number" id="age" name="age" required>
-        <label for="gender">Genre :</label>
-        <select id="gender" name="gender">
-            <option value="homme">Homme</option>
-            <option value="femme">Femme</option>
-        </select>
-        <button type="submit" class="button">Sauvegarder</button>
-    </form>
+    <h1>À propos</h1>
+    <p>Zwizz est un site pour rencontrer quelqu'un et découvrir où se trouvent les autres utilisateurs.</p>
 </main>
 <script src="script.js"></script>
 </body>

--- a/accueil.html
+++ b/accueil.html
@@ -12,10 +12,14 @@
     <a href="accueil.html">Accueil</a>
     <a href="map.html">Carte</a>
     <a href="profil.html">Profil</a>
+    <a href="about.html">À propos</a>
 </nav>
 <main>
     <h1>Bienvenue</h1>
     <a class="button" href="map.html">Aller sur la map</a>
+    <section id="profiles" style="margin-top:2em;">
+        <h2>Profils aléatoires</h2>
+    </section>
 </main>
 <script src="script.js"></script>
 </body>

--- a/map.html
+++ b/map.html
@@ -14,10 +14,12 @@
     <a href="accueil.html">Accueil</a>
     <a href="map.html">Carte</a>
     <a href="profil.html">Profil</a>
+    <a href="about.html">À propos</a>
 </nav>
 <main>
     <h1>Carte interactive</h1>
     <div id="map" style="height: 80vh;"></div>
+    <button id="remove-pin" class="button" style="margin-top:1em;">Supprimer mon pin</button>
 </main>
 <!-- Load Leaflet with CDN fallback -->
 <script src="node_modules/leaflet/dist/leaflet.js" onerror="this.onerror=null;this.src='https://unpkg.com/leaflet@1.9.4/dist/leaflet.js'"></script>

--- a/script.js
+++ b/script.js
@@ -41,7 +41,8 @@ function initMap() {
     const mapEl = document.getElementById('map');
     if (!mapEl) return;
 
-    const map = L.map(mapEl).setView([48.8584, 2.2945], 13);
+    // Montréal coordinates by default
+    const map = L.map(mapEl).setView([45.5019, -73.5674], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
@@ -71,7 +72,50 @@ function initMap() {
     });
 }
 
+function removeUserPin() {
+    const index = localStorage.getItem('userPinIndex');
+    if (index === null) {
+        alert("Vous n'avez pas encore placé de pin.");
+        return;
+    }
+    const pins = getPins();
+    if (pins[index]) {
+        pins.splice(index, 1);
+        savePins(pins);
+    }
+    localStorage.removeItem('userPinIndex');
+    location.reload();
+}
+
+function displayRandomProfiles() {
+    const container = document.getElementById('profiles');
+    if (!container) return;
+
+    const pins = getPins();
+    if (pins.length === 0) {
+        container.textContent = 'Aucun profil enregistré.';
+        return;
+    }
+    // Shuffle and take up to 3 profiles
+    const sample = pins
+        .slice()
+        .sort(() => Math.random() - 0.5)
+        .slice(0, 3);
+
+    sample.forEach(p => {
+        const div = document.createElement('div');
+        div.className = 'profile-card';
+        div.textContent = `${p.age} ans – ${p.gender} (lat: ${p.lat.toFixed(2)}, lng: ${p.lng.toFixed(2)})`;
+        container.appendChild(div);
+    });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     initProfileForm();
     initMap();
+    displayRandomProfiles();
+    const btn = document.getElementById('remove-pin');
+    if (btn) {
+        btn.addEventListener('click', removeUserPin);
+    }
 });

--- a/style.css
+++ b/style.css
@@ -70,6 +70,16 @@ select {
     margin-bottom: 10px;
 }
 
+#profiles {
+    margin-top: 2em;
+}
+
+.profile-card {
+    background: #f5f5f5;
+    padding: 1em;
+    border-radius: 4px;
+    margin-bottom: 1em;
+}
 #map {
     width: 100%;
     height: 80vh;


### PR DESCRIPTION
## Summary
- center map on Montréal
- allow removing and relocating user's pin
- display random profiles on the home page
- add À propos page describing the site
- link new page in navigation

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68743c8aa93c832ea3ff8b7bb959fc52