### PR TITLE
Fix pin deletion bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -142,7 +142,16 @@ function initMap() {
     handleZoom();
 }
 
-function removeUserPin() {
+function removeUserPin(e) {
+    if (e) {
+        if (e.originalEvent) {
+            e.originalEvent.stopPropagation();
+            e.originalEvent.preventDefault();
+        } else if (e.stopPropagation) {
+            e.stopPropagation();
+            if (e.preventDefault) e.preventDefault();
+        }
+    }
     const index = parseInt(localStorage.getItem('userPinIndex'), 10);
     if (Number.isNaN(index)) {
         alert("Vous n'avez pas encore placé de pin.");


### PR DESCRIPTION
## Summary
- prevent map click handler from re-adding pin when deleting it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68745f468244832e8c4c3f972ddc922f