### PR TITLE
Fix single pin constraint

### DIFF
--- a/script.js
+++ b/script.js
@@ -142,7 +142,7 @@ function initMap() {
     });
 
     map.on('click', e => {
-        if (localStorage.getItem('userPinIndex') !== null) {
+        if (localStorage.getItem('userPinIndex') !== null || userMarker) {
             alert('Vous avez déjà ajouté un pin.');
             return;
         }


### PR DESCRIPTION
## Summary
- prevent adding multiple pins by checking `userMarker` when handling map clicks

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(starts `http-server` then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_687481a2338c832eb7c80246abd82ca0