### PR TITLE
Ensure single pin per user

### DIFF
--- a/script.js
+++ b/script.js
@@ -106,6 +106,14 @@ function initMap() {
     // Ensure only one pin exists before initializing the map
     cleanupPins();
 
+    // Listen for storage changes from other tabs to keep state in sync
+    window.addEventListener('storage', e => {
+        if (e.key === 'pins' || e.key === 'userPinIndex') {
+            cleanupPins();
+            location.reload();
+        }
+    });
+
     const mapEl = document.getElementById('map');
     if (!mapEl) return;
 
@@ -142,6 +150,7 @@ function initMap() {
     });
 
     map.on('click', e => {
+        cleanupPins();
         if (localStorage.getItem('userPinIndex') !== null || userMarker) {
             alert('Vous avez déjà ajouté un pin.');
             return;


### PR DESCRIPTION
## Summary
- listen to `storage` events so only one pin remains even with multiple tabs
- check and clean up pins on each click

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68748449c30c832eb6017ba0054b16e4