### PR TITLE
Add policy modal on age page

### DIFF
--- a/age-check.js
+++ b/age-check.js
@@ -10,6 +10,26 @@ function calculateAge(birthDate) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('age-form');
+  const policyLink = document.getElementById('policy-link');
+  const policyModal = document.getElementById('policy-modal');
+  const policyOverlay = document.getElementById('policy-overlay');
+  const policyClose = document.getElementById('policy-close');
+
+  if (policyLink && policyModal && policyOverlay) {
+    policyLink.addEventListener('click', e => {
+      e.preventDefault();
+      policyModal.style.display = 'block';
+      policyOverlay.style.display = 'block';
+    });
+  }
+
+  if (policyClose && policyModal && policyOverlay) {
+    policyClose.addEventListener('click', () => {
+      policyModal.style.display = 'none';
+      policyOverlay.style.display = 'none';
+    });
+  }
+
   if (!form) return;
   form.addEventListener('submit', e => {
     e.preventDefault();

--- a/age.html
+++ b/age.html
@@ -15,12 +15,26 @@
     <input type="date" id="dob" required />
     <label style="margin-top:1em;">
       <input type="checkbox" id="policy-check" />
-      J'accepte la <a href="politique.html" target="_blank">politique d'utilisation</a>
+      J'accepte la <a href="#" id="policy-link">politique d'utilisation</a>
     </label>
     <button type="submit" class="button">Entrer</button>
   </form>
   <p id="age-error" style="color:red; display:none;">Vous devez avoir au moins 18 ans pour accéder au site.</p>
   <p id="policy-error" style="color:red; display:none;">Vous devez accepter la politique d'utilisation pour continuer.</p>
+  <div id="policy-overlay" class="modal-overlay" style="display:none;"></div>
+  <div id="policy-modal" class="modal" style="display:none;">
+    <h2>Politique d'utilisation</h2>
+    <p>Cette page décrit les règles essentielles pour participer au service Zwizz. En accédant au site, vous acceptez ces conditions :</p>
+    <ol>
+      <li>Zwizz permet uniquement de partager une localisation approximative. Les informations saisies restent dans votre navigateur et ne sont pas conservées par nos serveurs.</li>
+      <li>Vous vous engagez à respecter les autres utilisateurs et à ne pas publier de contenus injurieux, offensants ou illégaux.</li>
+      <li>Ne divulguez pas vos informations personnelles sensibles et soyez vigilant lors de toute rencontre avec des inconnus.</li>
+      <li>Zwizz n'est pas responsable des rencontres physiques. Prenez toujours les mesures de sécurité nécessaires et privilégiez les lieux publics.</li>
+      <li>Tout comportement abusif pourra entraîner une exclusion immédiate de la plateforme.</li>
+    </ol>
+    <p>En continuant, vous confirmez avoir lu et accepté cette politique.</p>
+    <button id="policy-close" class="button">Fermer</button>
+  </div>
 </main>
 <script src="age-check.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -159,6 +159,30 @@ select {
     margin-bottom: 0.5em;
 }
 
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.5);
+    z-index: 999;
+}
+
+.modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    padding: 1em;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+    z-index: 1000;
+    max-width: 90%;
+    overflow-y: auto;
+}
+
 #filter-menu {
     background: #fff;
     padding: 1em;


### PR DESCRIPTION
## Summary
- implement policy modal to avoid opening a new page
- style modal overlay
- handle opening/closing in age check script

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68748e9a7a3c832ebf93f31e0bf629ab