### PR TITLE
Add watermark background

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,28 @@ body {
     color: #333;
 }
 
+/* Faded logo watermark across all pages */
+body::before {
+    content: "";
+    background: url("logozwizz.png") no-repeat center center fixed;
+    background-size: contain;
+    opacity: 0.07;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    pointer-events: none;
+}
+
+/* Ensure content displays above the background */
+main,
+nav {
+    position: relative;
+    z-index: 1;
+}
+
 nav {
     background: #800080;
     padding: 0.5em 1em;


### PR DESCRIPTION
## Summary
- apply a faded `logozwizz.png` watermark on every page
- keep navigation and main content above the watermark

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(start then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6874a9126fc4832e864ad29921f9a652