### PR TITLE
Use image as page background

### DIFF
--- a/accueil.html
+++ b/accueil.html
@@ -8,24 +8,9 @@
     <title>Accueil</title>
 
     <style>
-      body::before {
-        content: "";
+      body {
         background: url("logozwizz.png") no-repeat center center fixed;
-        background-size: contain;
-        opacity: 0.15;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: 0;
-        pointer-events: none;
-      }
-
-      main,
-      nav {
-        position: relative;
-        z-index: 1;
+        background-size: cover;
       }
 
       .hero {

--- a/style.css
+++ b/style.css
@@ -2,24 +2,10 @@ body {
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
     padding: 0;
-    background: linear-gradient(to bottom, #fff, #ffe6f2);
+    background: url("logozwizz.png") no-repeat center center fixed;
+    background-size: cover;
     color: #333;
     animation: fadeIn 0.6s ease-in;
-}
-
-/* Faded logo watermark across all pages */
-body::before {
-    content: "";
-    background: url("logozwizz.png") no-repeat center center fixed;
-    background-size: contain;
-    opacity: 0.15;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 0;
-    pointer-events: none;
 }
 
 /* Ensure content displays above the background */


### PR DESCRIPTION
## Summary
- remove watermark pseudo-element from styles
- apply `logozwizz.png` as the body's background image
- update inline styles in `accueil.html`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874b2a6c9c0832e9476b6457b143faa