### PR TITLE
Add Firebase authentication support

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,7 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>À propos</h1>
@@ -28,6 +29,12 @@
     <p>Pas besoin d’attendre des jours ou de swiper dans le vide : tu vois qui est dispo maintenant, dans ta ville, et tu choisis si tu veux jaser ou aller plus loin.</p>
     <p>Zwizz, c’est l’humain d’abord, en toute simplicité.</p>
 </main>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(false);</script>
 </body>
 </html>

--- a/accueil.html
+++ b/accueil.html
@@ -114,6 +114,7 @@
       <a href="aide.html">Aide</a>
       <a href="about.html">À propos</a>
       <a href="#" id="logout-link">Déconnexion</a>
+      <span id="user-info"></span>
     </nav>
 
     <main>
@@ -236,7 +237,13 @@
         document.body.appendChild(leafletScript);
       });
     </script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script src="firebase-init.js"></script>
+    <script src="auth.js"></script>
     <script src="script.js"></script>
+    <script>initAuthGuard(false);</script>
     <script>
       function initMiniMap() {
         const container = document.getElementById("mini-map");

--- a/aide.html
+++ b/aide.html
@@ -17,6 +17,7 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>Aide</h1>
@@ -29,6 +30,12 @@
     <h2>Comment signaler un abus</h2>
     <button class="button" onclick="alert('Merci pour votre signalement.')">Signaler</button>
 </main>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(false);</script>
 </body>
 </html>

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,75 @@
+function initAuthGuard(requireAuth = false) {
+  firebase.auth().onAuthStateChanged(user => {
+    const span = document.getElementById('user-info');
+    if (span) span.textContent = user ? (user.displayName || user.email) : '';
+    const page = location.pathname.split('/').pop();
+    const authPages = ['login.html', 'signup.html'];
+    if (!user && requireAuth) {
+      window.location.href = 'login.html';
+    } else if (user && authPages.includes(page)) {
+      window.location.href = 'map.html';
+    }
+  });
+}
+
+function register(e) {
+  e.preventDefault();
+  const name = document.getElementById('name').value.trim();
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const age = parseInt(document.getElementById('age').value, 10);
+  const gender = document.getElementById('gender').value;
+  if (age < 18) {
+    alert('Vous devez avoir au moins 18 ans.');
+    return;
+  }
+  firebase.auth().createUserWithEmailAndPassword(email, password)
+    .then(cred => {
+      return Promise.all([
+        cred.user.updateProfile({ displayName: name }),
+        firebase.firestore().collection('users').doc(cred.user.uid).set({
+          uid: cred.user.uid,
+          nom: name,
+          email: cred.user.email,
+          age,
+          genre,
+          photoURL: cred.user.photoURL || null
+        })
+      ]);
+    })
+    .then(() => {
+      window.location.href = 'map.html';
+    })
+    .catch(err => alert(err.message));
+}
+
+function login(e) {
+  e.preventDefault();
+  const email = document.getElementById('login-email').value.trim();
+  const password = document.getElementById('login-password').value;
+  firebase.auth().signInWithEmailAndPassword(email, password)
+    .then(() => {
+      window.location.href = 'map.html';
+    })
+    .catch(err => alert(err.message));
+}
+
+function loginGoogle() {
+  const provider = new firebase.auth.GoogleAuthProvider();
+  firebase.auth().signInWithPopup(provider)
+    .then(result => {
+      const user = result.user;
+      return firebase.firestore().collection('users').doc(user.uid).set({
+        uid: user.uid,
+        nom: user.displayName || '',
+        email: user.email,
+        age: null,
+        genre: null,
+        photoURL: user.photoURL || null
+      }, { merge: true });
+    })
+    .then(() => {
+      window.location.href = 'map.html';
+    })
+    .catch(err => alert(err.message));
+}

--- a/favoris.html
+++ b/favoris.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Favoris</title>
 </head>
-<body>
+<body data-auth="required">
 <nav>
     <img src="logozwizz.png" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>
@@ -18,11 +18,18 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>Mes Favoris</h1>
     <div id="fav-list"></div>
 </main>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(true);</script>
 </body>
 </html>

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,0 +1,11 @@
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+firebase.initializeApp(firebaseConfig);
+window.auth = firebase.auth();
+window.db = firebase.firestore();

--- a/login.html
+++ b/login.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <title>Connexion</title>
+</head>
+<body>
+  <nav>
+    <img src="logozwizz.png" alt="Zwizz" class="logo">
+    <a href="accueil.html">Accueil</a>
+    <a href="map.html">Carte</a>
+    <a href="profil.html">Profil</a>
+    <a href="securite.html">Sécurité</a>
+    <a href="aide.html">Aide</a>
+    <a href="about.html">À propos</a>
+    <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
+  </nav>
+  <main>
+    <h1>Connexion</h1>
+    <form id="login-form">
+      <label for="login-email">Email</label>
+      <input type="email" id="login-email" required>
+      <label for="login-password">Mot de passe</label>
+      <input type="password" id="login-password" required>
+      <button type="submit" class="button">Se connecter</button>
+    </form>
+    <button id="google-login" class="button" style="margin-top:1em;">Connexion avec Google</button>
+    <p><a href="#">Mot de passe oublié ?</a></p>
+  </main>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+  <script src="firebase-init.js"></script>
+  <script src="auth.js"></script>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('login-form').addEventListener('submit', login);
+    document.getElementById('google-login').addEventListener('click', loginGoogle);
+    initAuthGuard(false);
+  </script>
+</body>
+</html>

--- a/map.html
+++ b/map.html
@@ -24,7 +24,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Carte</title>
 </head>
-<body>
+<body data-auth="required">
 <nav>
     <img src="logozwizz.png" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>
@@ -35,6 +35,7 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>Carte interactive</h1>
@@ -75,6 +76,12 @@
     document.body.appendChild(leafletScript);
   });
 </script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(true);</script>
 </body>
 </html>

--- a/politique.html
+++ b/politique.html
@@ -17,6 +17,7 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>Politique d'utilisation</h1>
@@ -30,6 +31,12 @@
     </ol>
     <p>En continuant, vous confirmez avoir lu et accepté cette politique.</p>
 </main>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(false);</script>
 </body>
 </html>

--- a/profil.html
+++ b/profil.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Profil</title>
 </head>
-<body>
+<body data-auth="required">
 <nav>
     <img src="logozwizz.png" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>
@@ -17,6 +17,7 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>Mon Profil</h1>
@@ -34,6 +35,12 @@
         <button type="submit" class="button">Sauvegarder</button>
     </form>
 </main>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(true);</script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -65,12 +65,15 @@ function escapeHtml(str) {
 }
 
 function logoutUser() {
+    if (window.firebase?.auth) {
+        firebase.auth().signOut().catch(() => {});
+    }
     localStorage.removeItem('ageVerified');
     localStorage.removeItem('birthDate');
     localStorage.removeItem('userInfo');
     localStorage.removeItem('pins');
     localStorage.removeItem('userPinIndex');
-    window.location.href = 'index.html';
+    window.location.href = 'login.html';
 }
 
 function cleanupPins() {
@@ -398,6 +401,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('section').forEach(sec => sec.classList.add('fade-section'));
     cleanupPins();
     initProfileForm();
+    initAuthGuard(document.body.dataset.auth === 'required');
     displayRandomProfiles();
     displayFavorites();
     const btn = document.getElementById('remove-pin');

--- a/securite.html
+++ b/securite.html
@@ -17,6 +17,7 @@
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
     <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
 </nav>
 <main>
     <h1>Conseils de sécurité</h1>
@@ -27,6 +28,12 @@
         <li>Ce site n’est pas responsable des rencontres physiques. Soyez prudents.</li>
     </ul>
 </main>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-init.js"></script>
+<script src="auth.js"></script>
 <script src="script.js"></script>
+<script>initAuthGuard(false);</script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <title>Inscription</title>
+</head>
+<body>
+  <nav>
+    <img src="logozwizz.png" alt="Zwizz" class="logo">
+    <a href="accueil.html">Accueil</a>
+    <a href="map.html">Carte</a>
+    <a href="profil.html">Profil</a>
+    <a href="securite.html">Sécurité</a>
+    <a href="aide.html">Aide</a>
+    <a href="about.html">À propos</a>
+    <a href="#" id="logout-link">Déconnexion</a>
+    <span id="user-info"></span>
+  </nav>
+  <main>
+    <h1>Inscription</h1>
+    <form id="signup-form">
+      <label for="name">Nom ou surnom</label>
+      <input type="text" id="name" required>
+      <label for="email">Email</label>
+      <input type="email" id="email" required>
+      <label for="password">Mot de passe</label>
+      <input type="password" id="password" required>
+      <label for="age">Âge</label>
+      <input type="number" id="age" required>
+      <label for="gender">Genre</label>
+      <select id="gender">
+        <option value="homme">Homme</option>
+        <option value="femme">Femme</option>
+        <option value="autre">Autre</option>
+      </select>
+      <button type="submit" class="button">S'inscrire</button>
+    </form>
+    <button id="google-signup" class="button" style="margin-top:1em;">Connexion avec Google</button>
+  </main>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+  <script src="firebase-init.js"></script>
+  <script src="auth.js"></script>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('signup-form').addEventListener('submit', register);
+    document.getElementById('google-signup').addEventListener('click', loginGoogle);
+    initAuthGuard(false);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate Firebase for authentication
- add signup and login pages
- redirect unauthenticated users
- show user name/email in navigation
- update logout to sign out from Firebase

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687594aa8f34832eb645075c1f5c2493