### PR TITLE
Remove plaintext Firebase keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+firebase-config.js

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ the map. All information is stored in the browser's `localStorage`.
 
 After cloning the repository, run `npm install` to fetch the local dependencies.
 You can then start a local server with `npm start` and open `http://localhost:8080` in your browser to get started.
+
+## Firebase configuration
+
+This project expects a `firebase-config.js` file containing your Firebase keys. A sample file named `firebase-config.sample.js` is provided. Copy it to `firebase-config.js` and fill in your own credentials. The resulting file is ignored by git to keep your keys private.

--- a/about.html
+++ b/about.html
@@ -32,6 +32,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/accueil.html
+++ b/accueil.html
@@ -240,6 +240,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
     <script src="firebase-init.js"></script>
     <script src="auth.js"></script>
     <script src="script.js"></script>

--- a/aide.html
+++ b/aide.html
@@ -33,6 +33,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/favoris.html
+++ b/favoris.html
@@ -27,6 +27,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/firebase-config.sample.js
+++ b/firebase-config.sample.js
@@ -1,0 +1,9 @@
+window.firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+  measurementId: "YOUR_MEASUREMENT_ID"
+};

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,11 +1,7 @@
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
-  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
-  appId: "YOUR_APP_ID"
-};
-firebase.initializeApp(firebaseConfig);
-window.auth = firebase.auth();
-window.db = firebase.firestore();
+if (typeof window.firebaseConfig === 'undefined') {
+  console.error('Firebase configuration not found.');
+} else {
+  firebase.initializeApp(window.firebaseConfig);
+  window.auth = firebase.auth();
+  window.db = firebase.firestore();
+}

--- a/login.html
+++ b/login.html
@@ -34,6 +34,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
   <script src="firebase-init.js"></script>
   <script src="auth.js"></script>
   <script src="script.js"></script>

--- a/map.html
+++ b/map.html
@@ -79,6 +79,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/politique.html
+++ b/politique.html
@@ -34,6 +34,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/profil.html
+++ b/profil.html
@@ -40,6 +40,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/securite.html
+++ b/securite.html
@@ -31,6 +31,7 @@
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>

--- a/signup.html
+++ b/signup.html
@@ -43,6 +43,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+<script src="firebase-config.js"></script>
   <script src="firebase-init.js"></script>
   <script src="auth.js"></script>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- avoid committing credentials by loading `firebaseConfig` from `firebase-config.js`
- ignore `firebase-config.js` and ship a `firebase-config.sample.js` template
- document Firebase setup in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875a1ee9a54832ea2873e81dc07abdd