### PR TITLE
Embed Firebase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-firebase-config.js

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ You can then start a local server with `npm start` and open `http://localhost:80
 
 ## Firebase configuration
 
-This project expects a `firebase-config.js` file containing your Firebase keys. A sample file named `firebase-config.sample.js` is provided. Copy it to `firebase-config.js` and fill in your own credentials. The resulting file is ignored by git to keep your keys private.
+The repository already includes a `firebase-config.js` file that contains the Firebase
+credentials used by the site, so no additional setup is required.

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,9 @@
+window.firebaseConfig = {
+  apiKey: "AIzaSyAOurZ3l380i3LMY3-vdAGNRd0KqpYsLp8",
+  authDomain: "zwizz-77189.firebaseapp.com",
+  projectId: "zwizz-77189",
+  storageBucket: "zwizz-77189.firebasestorage.app",
+  messagingSenderId: "840196240615",
+  appId: "1:840196240615:web:41c8ce2be084930bd29e42",
+  measurementId: "G-MXTXZ9S8ZY"
+};


### PR DESCRIPTION
## Summary
- remove env-based config generation
- include `firebase-config.js` with credentials
- simplify README setup instructions
- revert start script to plain `http-server`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875a5afa4b4832ea138164067e20cb2