### PR TITLE
Add signup link

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/accueil.html
+++ b/accueil.html
@@ -113,6 +113,8 @@
       <a href="securite.html">Sécurité</a>
       <a href="aide.html">Aide</a>
       <a href="about.html">À propos</a>
+      <a href="login.html" id="login-link">Connexion</a>
+      <a href="signup.html" id="signup-link">Inscription</a>
       <a href="#" id="logout-link">Déconnexion</a>
       <span id="user-info"></span>
     </nav>

--- a/aide.html
+++ b/aide.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/auth.js
+++ b/auth.js
@@ -2,6 +2,12 @@ function initAuthGuard(requireAuth = false) {
   firebase.auth().onAuthStateChanged(user => {
     const span = document.getElementById('user-info');
     if (span) span.textContent = user ? (user.displayName || user.email) : '';
+    const loginLink = document.getElementById('login-link');
+    const signupLink = document.getElementById('signup-link');
+    const logoutLink = document.getElementById('logout-link');
+    if (loginLink) loginLink.style.display = user ? 'none' : 'inline';
+    if (signupLink) signupLink.style.display = user ? 'none' : 'inline';
+    if (logoutLink) logoutLink.style.display = user ? 'inline' : 'none';
     const page = location.pathname.split('/').pop();
     const authPages = ['login.html', 'signup.html'];
     if (!user && requireAuth) {

--- a/favoris.html
+++ b/favoris.html
@@ -17,6 +17,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/login.html
+++ b/login.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
   </nav>

--- a/map.html
+++ b/map.html
@@ -34,6 +34,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/politique.html
+++ b/politique.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/profil.html
+++ b/profil.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/securite.html
+++ b/securite.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>

--- a/signup.html
+++ b/signup.html
@@ -16,6 +16,8 @@
     <a href="securite.html">Sécurité</a>
     <a href="aide.html">Aide</a>
     <a href="about.html">À propos</a>
+    <a href="login.html" id="login-link">Connexion</a>
+    <a href="signup.html" id="signup-link">Inscription</a>
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
   </nav>


### PR DESCRIPTION
## Summary
- display Signup and Login links in the navbar
- show/hide those links based on authentication state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875a9eba554832e8c56190c71862ea2