### PR TITLE
Implement policy, login check and pin sharing

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -62,6 +62,14 @@ function register(e) {
 
 function login(e) {
   e.preventDefault();
+  const termsAccepted = document.getElementById('terms-check')?.checked;
+  const termsErr = document.getElementById('terms-error');
+  if (termsErr) termsErr.style.display = 'none';
+  if (!termsAccepted) {
+    if (termsErr) termsErr.style.display = 'block';
+    else alert("Tu dois accepter les conditions d'utilisation.");
+    return;
+  }
   const email = document.getElementById('login-email').value.trim();
   const password = document.getElementById('login-password').value;
   firebase.auth().signInWithEmailAndPassword(email, password)

--- a/login.html
+++ b/login.html
@@ -22,7 +22,14 @@
     <span id="user-info"></span>
   </nav>
   <main>
-    <h1>Connexion</h1>
+    <h1>Zwizz est un espace de rencontres réservé aux 18 ans et plus.</h1>
+    <p>En te connectant, tu confirmes être majeur(e) et accepter notre <a href="politique.html">politique d’utilisation</a>.<br>
+    Aucune tolérance pour les faux profils, les comportements irrespectueux ou les abus.</p>
+    <label style="margin-bottom:1em; display:block;">
+      <input type="checkbox" id="terms-check"> ✅ Coche la case pour continuer
+    </label>
+    <p id="terms-error" style="color:red; display:none;">Tu dois accepter les conditions d’utilisation avant d’accéder à la plateforme.</p>
+    <h2>Connexion</h2>
     <form id="login-form">
       <label for="login-email">Email</label>
       <input type="email" id="login-email" required>

--- a/politique.html
+++ b/politique.html
@@ -22,16 +22,32 @@
     <span id="user-info"></span>
 </nav>
 <main>
-    <h1>Politique d'utilisation</h1>
-    <p>Cette page décrit les règles essentielles pour participer au service Zwizz. En accédant au site, vous acceptez ces conditions :</p>
-    <ol>
-        <li>Zwizz permet uniquement de partager une localisation approximative. Les informations saisies restent dans votre navigateur et ne sont pas conservées par nos serveurs.</li>
-        <li>Vous vous engagez à respecter les autres utilisateurs et à ne pas publier de contenus injurieux, offensants ou illégaux.</li>
-        <li>Ne divulguez pas vos informations personnelles sensibles et soyez vigilant lors de toute rencontre avec des inconnus.</li>
-        <li>Zwizz n'est pas responsable des rencontres physiques. Prenez toujours les mesures de sécurité nécessaires et privilégiez les lieux publics.</li>
-        <li>Tout comportement abusif pourra entraîner une exclusion immédiate de la plateforme.</li>
-    </ol>
-    <p>En continuant, vous confirmez avoir lu et accepté cette politique.</p>
+    <h1>🛡️ Politique d’utilisation de Zwizz</h1>
+    <p>Bienvenue sur Zwizz, une plateforme de rencontre pensée pour créer des liens rapides, spontanés et respectueux.<br>
+    En utilisant Zwizz, vous acceptez les conditions suivantes :</p>
+
+    <h2>🔞 1.A Âge minimum requis</h2>
+    <p>Zwizz est réservé aux personnes âgées de 18 ans et plus. En accédant au site, vous confirmez être majeur(e). Tout compte soupçonné de fausse déclaration d’âge pourra être suspendu sans préavis.</p>
+
+    <h2>📍 1.B Données personnelles et confidentialité</h2>
+    <p>Zwizz ne conserve aucune donnée personnelle sur ses serveurs.</p>
+    <p>Les informations que vous saisissez (nom, genre, âge, localisation approximative) restent stockées dans votre navigateur localement.</p>
+    <p>Nous ne traçons ni ne vendons vos données.</p>
+    <p>Votre localisation est volontaire, approximative et jamais partagée précisément.</p>
+
+    <h2>🤝 1.C Respect et comportement</h2>
+    <p>Le respect mutuel est essentiel. Vous vous engagez à ne pas publier ni partager de contenu insultant, violent, discriminatoire, sexuel explicite, ou illégal.</p>
+    <p>Zwizz applique une politique de tolérance zéro envers tout comportement abusif, harcèlement, usurpation d'identité ou tentative d'arnaque.</p>
+
+    <h2>🧠 1.D Sécurité personnelle</h2>
+    <p>Vous êtes entièrement responsable de vos interactions avec les autres utilisateurs.</p>
+    <p>Zwizz ne garantit ni la véracité des profils, ni la sécurité des rencontres physiques.</p>
+    <p>Ne partagez jamais d’informations sensibles ou confidentielles, même si la conversation semble de confiance.</p>
+    <p>Lors d’une rencontre réelle, privilégiez toujours les lieux publics et informez un proche.</p>
+
+    <h2>❌1.E Sanctions et modération</h2>
+    <p>Tout utilisateur enfreignant ces règles pourra être exclu immédiatement de la plateforme, sans avertissement.</p>
+    <p>Zwizz se réserve le droit de restreindre l'accès ou de bloquer tout utilisateur pour comportement inapproprié ou signalements répétés.</p>
 </main>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>


### PR DESCRIPTION
## Summary
- add age/terms acceptance checkbox on login
- store pins in Firestore so they are visible for everyone
- require birthdate check when messaging and auto-open modal after verifying
- update the policy page with new text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875b831ce8c832eb4af25fce37f4dc1