### PR TITLE
Fix pin persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This small website displays an interactive map using [Leaflet](https://leafletjs.com/).
 Users can save their name, age and gender in the profile page and place a single pin on
-the map. All information is stored in the browser's `localStorage`.
+the map. Pins are stored locally in the browser and synchronised with Firebase
+Firestore so they remain visible even after a refresh or on another device.
 
 After cloning the repository, run `npm install` to fetch the local dependencies.
 You can then start a local server with `npm start` and open `http://localhost:8080` in your browser to get started.

--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,10 @@
 function initAuthGuard(requireAuth = false) {
   firebase.auth().onAuthStateChanged(user => {
+    if (user) {
+      if (typeof syncPinsFromFirestore === 'function') {
+        syncPinsFromFirestore().catch(() => {});
+      }
+    }
     const span = document.getElementById('user-info');
     if (span) span.textContent = user ? (user.displayName || user.email) : '';
     const loginLink = document.getElementById('login-link');

--- a/script.js
+++ b/script.js
@@ -39,12 +39,23 @@ let mapInstance = null;
 
 async function fetchFirestorePins() {
     if (!window.db) return [];
-    const snap = await db.collection('pins').get();
-    return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    try {
+        const snap = await db.collection('pins').get();
+        return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    } catch (err) {
+        console.error('Failed to fetch pins from Firestore:', err);
+        return getPins();
+    }
 }
 
 async function syncPinsFromFirestore() {
-    const pins = await fetchFirestorePins();
+    let pins = [];
+    try {
+        pins = await fetchFirestorePins();
+    } catch (err) {
+        console.error('Error syncing pins from Firestore:', err);
+        pins = getPins();
+    }
     savePins(pins);
     const uid = firebase.auth().currentUser?.uid;
     const idx = pins.findIndex(p => p.id === uid);


### PR DESCRIPTION
## Summary
- load pins from Firestore whenever auth state changes
- handle Firestore failures gracefully when fetching pins
- clarify pin persistence in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875c3cc3acc832eae3b7303bd524478