### PR TITLE
Fix asynchronous deletion for pins

### DIFF
--- a/script.js
+++ b/script.js
@@ -366,7 +366,7 @@ async function initMap() {
     handleZoom();
 }
 
-function removeUserPin(e) {
+async function removeUserPin(e) {
     if (e) {
         if (e.originalEvent) {
             e.originalEvent.stopPropagation();
@@ -390,7 +390,11 @@ function removeUserPin(e) {
     savePins(pins);
     localStorage.removeItem('userPinIndex');
     if (uid && window.db) {
-        db.collection('pins').doc(uid).delete().catch(() => {});
+        try {
+            await db.collection('pins').doc(uid).delete();
+        } catch (_) {
+            // ignore errors
+        }
     }
     if (userMarker) {
         userMarker.remove();


### PR DESCRIPTION
## Summary
- wait for Firestore delete to complete when removing a pin

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875c5000a0c832e8bb8fa20493d6117