### PR TITLE
Fix leftover pin duplicates

### DIFF
--- a/script.js
+++ b/script.js
@@ -400,6 +400,12 @@ async function removeUserPin(e) {
     if (uid && window.db) {
         try {
             await db.collection('pins').doc(uid).delete();
+            const snap = await db.collection('pins').where('id', '==', uid).get();
+            const promises = [];
+            snap.forEach(doc => {
+                if (doc.id !== uid) promises.push(doc.ref.delete());
+            });
+            await Promise.all(promises);
         } catch (err) {
             alert('Impossible de supprimer le pin.');
             return;


### PR DESCRIPTION
## Summary
- clean up any Firestore documents with the user's id when removing the pin

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875d11def3c832ea9ebce2ed76b24a1