### PR TITLE
Fix user pin deletion on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -569,7 +569,6 @@ function applyFilters() {
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('section').forEach(sec => sec.classList.add('fade-section'));
     await syncUserInfoFromFirestore();
-    await cleanupPins();
     await syncPinsFromFirestore();
     await cleanupPins();
     displayRandomProfiles();


### PR DESCRIPTION
## Summary
- avoid clearing user pin before syncing pins from Firestore

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875e2eab2c8832e9d21a0661a3430e8