### PR TITLE
Fix pin cleanup query

### DIFF
--- a/script.js
+++ b/script.js
@@ -180,7 +180,7 @@ async function cleanupPins() {
         if (window.db) {
             try {
                 await db.collection('pins').doc(uid).delete();
-                const snap = await db.collection('pins').where('id', '==', uid).get();
+                const snap = await db.collection('pins').where('uid', '==', uid).get();
                 const promises = [];
                 snap.forEach(doc => {
                     if (doc.id !== uid) promises.push(doc.ref.delete());


### PR DESCRIPTION
## Summary
- fix the Firestore field queried when cleaning up pins

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875e983f928832e98d89bc53b721446