### PR TITLE
Implement profils collection and improved pin schema

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -47,7 +47,7 @@ function register(e) {
     .then(cred => {
       return Promise.all([
         cred.user.updateProfile({ displayName: name }),
-        firebase.firestore().collection('users').doc(cred.user.uid).set({
+        firebase.firestore().collection('profils').doc(cred.user.uid).set({
           uid: cred.user.uid,
           nom: name,
           email: cred.user.email,
@@ -89,7 +89,7 @@ function loginGoogle() {
   firebase.auth().signInWithPopup(provider)
     .then(result => {
       const user = result.user;
-      return firebase.firestore().collection('users').doc(user.uid).set({
+      return firebase.firestore().collection('profils').doc(user.uid).set({
         uid: user.uid,
         nom: user.displayName || '',
         email: user.email,


### PR DESCRIPTION
## Summary
- store user profiles in a `profils` Firestore collection
- include pin profile snapshots and timestamp when saving pins
- update pin fetch logic to read the new structure

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875ec07c8f8832e882918884c133c5b