### PR TITLE
Preserve profile info across logout

### DIFF
--- a/script.js
+++ b/script.js
@@ -149,9 +149,8 @@ function logoutUser() {
     }
     localStorage.removeItem('ageVerified');
     localStorage.removeItem('birthDate');
-    localStorage.removeItem('userInfo');
-    localStorage.removeItem('pins');
-    localStorage.removeItem('userPinIndex');
+    // Do not clear userInfo, pins or userPinIndex so profile details and
+    // markers remain after logout
     window.location.href = 'login.html';
 }
 


### PR DESCRIPTION
## Summary
- keep `userInfo`, `pins` and `userPinIndex` when logging out so profile data and map pins persist

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875f2d60848832e8eb58d7b2aa4220d