### PR TITLE
Ensure profile loads after re-login

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -4,6 +4,9 @@ function initAuthGuard(requireAuth = false) {
       if (typeof syncPinsFromFirestore === 'function') {
         syncPinsFromFirestore().catch(() => {});
       }
+      if (typeof syncUserInfoFromFirestore === 'function') {
+        syncUserInfoFromFirestore().catch(() => {});
+      }
     }
     const span = document.getElementById('user-info');
     if (span) span.textContent = user ? (user.displayName || user.email) : '';


### PR DESCRIPTION
## Summary
- load the user profile after the authentication state is available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876022dcf30832e94acbdbc7129eece