### PR TITLE
Add conversation messaging system

### DIFF
--- a/map.html
+++ b/map.html
@@ -57,10 +57,6 @@
     </div>
     <div id="map" style="height: 80vh;"></div>
     <button id="remove-pin" class="button" style="margin-top:1em;">Supprimer mon pin</button>
-    <div id="message-modal" class="message-box" style="display:none;">
-        <textarea></textarea>
-        <button>Envoyer</button>
-    </div>
 </main>
 <!-- Load Leaflet with CDN fallback -->
 <script>

--- a/message.html
+++ b/message.html
@@ -23,9 +23,16 @@
     <a href="#" id="logout-link">Déconnexion</a>
     <span id="user-info"></span>
 </nav>
-<main>
-    <h1>Messages</h1>
-    <div id="messages-container"></div>
+<main id="conversation">
+    <div id="conversation-header">
+        <img id="convo-photo" class="popup-photo" style="display:none;">
+        <h1 id="convo-name"></h1>
+    </div>
+    <div id="conversation-messages"></div>
+    <form id="send-form">
+        <input id="message-input" type="text" placeholder="Écrire un message" autocomplete="off">
+        <button type="submit">Envoyer</button>
+    </form>
 </main>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
@@ -34,6 +41,6 @@
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>
-<script>initAuthGuard(true); displayMessages();</script>
+<script>initAuthGuard(true); const uid = new URLSearchParams(location.search).get('uid'); if(uid){displayConversation(uid);}</script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2,9 +2,8 @@ body {
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
     padding: 0;
-    background: url("logozwizz.png") no-repeat center center fixed;
-    background-size: cover;
-    color: #333;
+    background: #000;
+    color: #fff;
     animation: fadeIn 0.6s ease-in;
 }
 
@@ -16,7 +15,7 @@ nav {
 }
 
 nav {
-    background: #800080;
+    background: #4b0082;
     padding: 0.5em 1em;
     display: flex;
     flex-wrap: wrap;
@@ -97,16 +96,16 @@ nav a:hover {
 main {
     max-width: 800px;
     margin: 2em auto;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(20, 20, 20, 0.9);
     padding: 2em;
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .button {
     display: inline-block;
     padding: 10px 20px;
-    background: linear-gradient(45deg, #ff0000, #800080);
+    background: linear-gradient(45deg, #4b0082, #800080);
     color: #fff;
     text-decoration: none;
     border-radius: 4px;
@@ -114,7 +113,7 @@ main {
 }
 
 .button:hover {
-    background: linear-gradient(45deg, #800080, #ff0000);
+    background: linear-gradient(45deg, #800080, #4b0082);
     transform: scale(1.05);
 }
 
@@ -283,4 +282,74 @@ select {
 #likes-count {
     font-weight: bold;
     margin-top: 0.5em;
+}
+
+#conversation-header {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #333;
+    padding-bottom: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+#convo-photo {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin-right: 0.5em;
+}
+
+#conversation-messages {
+    height: calc(100vh - 200px);
+    overflow-y: auto;
+    padding-bottom: 1em;
+}
+
+.chat-message {
+    margin: 0.4em 0;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.chat-message.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+.chat-message span {
+    display: inline-block;
+    padding: 0.4em 0.8em;
+    border-radius: 12px;
+}
+.chat-message.sent {
+    text-align: right;
+}
+.chat-message.sent span {
+    background: #4b0082;
+}
+.chat-message.received span {
+    background: #333;
+}
+
+#send-form {
+    position: sticky;
+    bottom: 0;
+    display: flex;
+    background: #000;
+    padding: 0.5em 0;
+}
+#message-input {
+    flex: 1;
+    padding: 0.5em;
+    border-radius: 20px;
+    border: none;
+    margin-right: 0.5em;
+    background: #222;
+    color: #fff;
+}
+#send-form button {
+    background: #4b0082;
+    color: #fff;
+    border: none;
+    border-radius: 20px;
+    padding: 0 1em;
 }


### PR DESCRIPTION
## Summary
- create conversation page with dynamic header and sticky input
- start a conversation from the map popup
- store conversations and messages in Firestore
- switch site to dark theme with violet accents
- style conversation messages with smooth animations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876a49c063c832e87c2d8def6678e6d