### PR TITLE
Fix background style for messages page

### DIFF
--- a/message.html
+++ b/message.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Messages</title>
 </head>
-<body data-auth="required">
+<body class="message-page" data-auth="required">
 <nav>
     <img src="logozwizz.png" alt="Zwizz" class="logo">
     <a href="accueil.html">Accueil</a>

--- a/style.css
+++ b/style.css
@@ -2,9 +2,15 @@ body {
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
     padding: 0;
+    background: url("logozwizz.png") no-repeat center center fixed;
+    background-size: cover;
+    color: #333;
+    animation: fadeIn 0.6s ease-in;
+}
+
+body.message-page {
     background: #000;
     color: #fff;
-    animation: fadeIn 0.6s ease-in;
 }
 
 /* Ensure content displays above the background */
@@ -96,9 +102,14 @@ nav a:hover {
 main {
     max-width: 800px;
     margin: 2em auto;
-    background: rgba(20, 20, 20, 0.9);
+    background: rgba(255, 255, 255, 0.9);
     padding: 2em;
     border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+body.message-page main {
+    background: rgba(20, 20, 20, 0.9);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 


### PR DESCRIPTION
## Summary
- only apply dark background on `message.html`
- revert global body and main styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876a6baa5bc832e9e20cc54654aa42f