### PR TITLE
Fix mobile nav overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -275,11 +275,20 @@ select {
         font-size: 14px;
     }
     nav a {
-        margin: 0.2em;
+        margin: 0 0.5em;
     }
     nav {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        align-items: center;
+        white-space: nowrap;
+    }
+    nav::-webkit-scrollbar {
+        display: none;
+    }
+    nav a {
+        flex: 0 0 auto;
     }
     form {
         width: 90%;


### PR DESCRIPTION
## Summary
- keep nav items in a single row on small screens
- make nav horizontally scrollable on mobile

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876b0f32558832e90c519f02eeac753