### PR TITLE
Fix JS syntax preventing map and profile features

### DIFF
--- a/script.js
+++ b/script.js
@@ -935,6 +935,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (form) form.style.display = 'none';
             if (noConvo) noConvo.style.display = 'block';
         }
+    }
 
     if (document.getElementById('messages-container')) {
         displayMessages();


### PR DESCRIPTION
## Summary
- close an unbalanced brace in `script.js` that broke all DOM handlers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876be94665c832eb279938b6ce6839f