### PR TITLE
Add conversation modal and Firestore chat

### DIFF
--- a/map.html
+++ b/map.html
@@ -43,6 +43,13 @@
     </div>
     <div id="map" style="height: 80vh;"></div>
     <button id="remove-pin" class="button" style="margin-top:1em;">Supprimer mon pin</button>
+    <div id="message-overlay" class="modal-overlay" style="display:none;"></div>
+    <div id="message-modal" class="modal" style="display:none;">
+        <form id="message-modal-form">
+            <textarea id="message-modal-text" placeholder="Écrire un message" required></textarea>
+            <button type="submit" class="button">Envoyer</button>
+        </form>
+    </div>
 </main>
 <!-- Load Leaflet with CDN fallback -->
 <script>

--- a/style.css
+++ b/style.css
@@ -229,6 +229,19 @@ select {
     margin-bottom: 0.5em;
 }
 
+#message-modal textarea {
+    width: 100%;
+    height: 80px;
+    margin-bottom: 0.5em;
+    background: #222;
+    color: #fff;
+    border: 1px solid #555;
+    border-radius: 4px;
+}
+#message-modal .button {
+    width: 100%;
+}
+
 #messages-container {
     position: absolute;
     top: 1em;


### PR DESCRIPTION
## Summary
- add dialog on map to send first message
- store chats in Firestore conversations/messages
- style message modal
- handle modal logic in JS

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876c5dddb58832e8f0294c0486b4bcf