### PR TITLE
Fix conversation initialization after auth

### DIFF
--- a/message.html
+++ b/message.html
@@ -32,6 +32,6 @@
 <script src="firebase-init.js"></script>
 <script src="auth.js"></script>
 <script src="script.js"></script>
-<script>fetch("nav.html").then(r=>r.text()).then(html=>{document.getElementById("nav-container").innerHTML=html;initAuthGuard(true);initDrawer(); const uid = new URLSearchParams(location.search).get("uid"); if(uid){displayConversation(uid);}});</script>
+<script>fetch("nav.html").then(r=>r.text()).then(html=>{document.getElementById("nav-container").innerHTML=html;initAuthGuard(true);initDrawer(); const uid=new URLSearchParams(location.search).get("uid"); if(uid){const f=()=>displayConversation(uid); if(firebase.auth().currentUser)f(); else firebase.auth().onAuthStateChanged(f);}});</script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1037,7 +1037,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (convoEl) {
         const uid = getQueryParam('uid');
         if (uid) {
-            displayConversation(uid);
+            const start = () => displayConversation(uid);
+            if (firebase.auth().currentUser) start();
+            else firebase.auth().onAuthStateChanged(start);
         } else {
             const area = document.getElementById('conversation-area');
             const noConvo = document.getElementById('no-conversation');


### PR DESCRIPTION
## Summary
- display messages only after Firebase auth is initialized
- wait for auth before redirecting on message page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf49661c832e9f2fa81fa1d157bc